### PR TITLE
The return type of ColumnDouble should be void

### DIFF
--- a/SQLite.cs
+++ b/SQLite.cs
@@ -1420,7 +1420,7 @@ namespace SQLite
         }
 
 	    [DllImport("sqlite3", EntryPoint = "sqlite3_column_double_interop")]
-		private static extern double ColumnDouble (IntPtr stmt, int index, out double value);
+		private static extern void ColumnDouble (IntPtr stmt, int index, out double value);
 
 	    public static double ColumnDouble(IntPtr stmt, int index)
         {


### PR DESCRIPTION
The return type of ColumnDouble (interop) should be void otherwise a NotSupportedException is thrown
